### PR TITLE
Modify positional arguments on zfs command line for Solaris 11

### DIFF
--- a/src/zfstools/connection.py
+++ b/src/zfstools/connection.py
@@ -30,8 +30,8 @@ class ZFSConnection:
 
     def _get_poolset(self):
         if self._dirty:
-            stdout = subprocess.check_output(self.command + ["list", "-r", "-t", "all", "-H", "-o", "name"])
-            stdout2 = subprocess.check_output(self.command + ["get", "-r", "-o", "name,value", "creation", "-Hp"])
+            stdout = subprocess.check_output(self.command + ["list", "-Hr", "-t", "all", "-o", "name"])
+            stdout2 = subprocess.check_output(self.command + ["get", "-Hpr", "-o", "name,value", "creation"])
             self._poolset.parse_zfs_r_output(stdout,stdout2)
             self._dirty = False
         return self._poolset


### PR DESCRIPTION
Solaris 11 doesn't like the arrangement of the positional arguments to the "zfs" command in connection.py. Eg:

  # zfs get -r -o name,value creation -Hp
  cannot open '-Hp': dataset does not exist
