### PR TITLE
zlock addition to zbackup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ The utilities let you do this:
    This uses zsnap and zreplicate to do the work, which is all driven by properties.
    For details, see this [further description of zbackup](doc/README-zbackup.md).
 
+6. zlock:
+   a command to lock a filesystem against replication by zbackup.
+   For details, see this [further description of zbackup](doc/README-zbackup.md).
+
 The repository, bug tracker and Web site for this tool is at [http://github.com/Rudd-O/zfs-tools](http://github.com/Rudd-O/zfs-tools).  Comments to me through rudd-o@rudd-o.com.
 
 ##Setting up

--- a/bin/zbackup
+++ b/bin/zbackup
@@ -99,22 +99,42 @@ def snapshot(tier, filesystem, take_snapshot, keep, options):
     subprocess.check_call(zsnap_command)
 
 def replicate(filesystem, destination, options):
-    """Replicate given filesystem, possibly after deleting snapshots from other tiers."""
+    """Replicate given filesystem, possibly after deleting snapshots from other tiers.
+Replication is only performed if a zlock can be acquired on the filesystem."""
     # delete other tiers snapshots first?
     if options.delete_tiers != None:
         for tier in options.delete_tiers.split(','):
             snapshot(tier, filesystem, False, 0, options)
-    # replicate
-    zreplicate_command = ['zreplicate', '--create-destination', '--no-replication-stream']
+    # lock/unlock on filesystem
+    zlock_lock_command = ['zlock', 'lock']
+    zlock_unlock_command = ['zlock', 'unlock']
+    zlock_args = []
     if options.verbose:
-        zreplicate_command += ['-v']
+        zlock_args += ['-v']
     if options.dryrun:
-        zreplicate_command += ['-n']
-    if options.zreplicate_options != None:
-        zreplicate_command += options.zreplicate_options.split()
-    zreplicate_command += [filesystem, destination]
-    verbose_stderr("%s" % highlight(' '.join(zreplicate_command)))
-    subprocess.check_call(zreplicate_command)
+        zlock_args += ['-n']
+    zlock_args += [filesystem]
+    verbose_stderr("%s" % ' '.join(zlock_lock_command + zlock_args))
+    if subprocess.call(zlock_lock_command + zlock_args) == 0:
+        # acquired lock, so replicate
+        zreplicate_command = ['zreplicate', '--create-destination', '--no-replication-stream']
+        if options.verbose:
+            zreplicate_command += ['-v']
+        if options.dryrun:
+            zreplicate_command += ['-n']
+        if options.zreplicate_options != None:
+            zreplicate_command += options.zreplicate_options.split()
+        zreplicate_command += [filesystem, destination]
+        try:
+            verbose_stderr("%s" % highlight(' '.join(zreplicate_command)))
+            subprocess.check_call(zreplicate_command)
+        finally:
+            # release lock
+            verbose_stderr("%s" % ' '.join(zlock_unlock_command + zlock_args))
+            subprocess.check_call(zlock_unlock_command + zlock_args)
+    else:
+        verbose_stderr("skipping replication for %s" % filesystem)
+        
 
 def property_has_value(properties, property_name):
     """Return whether the property has a (not none) value."""

--- a/bin/zbackup
+++ b/bin/zbackup
@@ -133,6 +133,8 @@ Replication is only performed if a zlock can be acquired on the filesystem."""
             verbose_stderr("%s" % ' '.join(zlock_unlock_command + zlock_args))
             subprocess.check_call(zlock_unlock_command + zlock_args)
     else:
+        if options.email_failure != None:
+            send_failure_email(options.email_failure, "%s has a zlock in place, use zlock list -v to troubleshoot" % filesystem)
         verbose_stderr("skipping replication for %s" % filesystem)
         
 

--- a/bin/zlock
+++ b/bin/zlock
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+#
+# zlock - lock a ZFS filesystem from being replicated by zbackup.
+#
+# In fact, the parameter filesystem is not validated to be a real ZFS filesystem,
+# since we choose not to care if the user locks a non-existent filesystem.
+#
+# There is no validation that the unlocker is the one holding the lock.
+#
+# Author: Simon Guest, 22/9/2014
+# Licensed under GNU General Public License GPLv3
+
+import optparse
+import os
+import os.path
+import sys
+from zfstools.util import stderr, verbose_stderr, set_verbose
+
+LOCKDIR = "/var/lib/zfs-tools/zlock"
+
+def ensure_lockdir_exists():
+    if not os.path.isdir(LOCKDIR):
+        os.makedirs(LOCKDIR, 0755)
+
+def filesystem2lockfile(filesystem):
+    return filesystem.replace('/', ';')
+
+def lockfile2filesystem(lockfile):
+    return lockfile.replace(';', '/')
+
+def readme_comment(readme, prefix):
+    try:
+        with open(readme, 'r') as f:
+            comment = "%s%s" % (prefix, f.read().rstrip('\n'))
+    except IOError:
+        comment = ""
+    return comment
+
+def lockpath_comment(lockpath, prefix):
+    return readme_comment(os.path.join(lockpath, "README"), prefix)
+
+def lock(filesystem, options):
+    """Attempt to lock filesystem, return whether we did."""
+    lockpath = os.path.join(LOCKDIR, filesystem2lockfile(filesystem))
+    readme = os.path.join(lockpath, "README")
+    if options.dryrun:
+        # test whether lock is available, don't actually acquire it
+        if os.path.isdir(lockpath):
+            verbose_stderr("zlock: (dry-run) would fail to lock %s%s" % (filesystem, readme_comment(readme, " - ")))
+            return False
+        else:
+            verbose_stderr("zlock: (dry-run) would lock %s" % filesystem)
+            return True
+    else:
+        try:
+            os.mkdir(lockpath)
+            if options.comment:
+                # write a comment if we can
+                try:
+                    with open(readme, 'w') as f:
+                        f.write("%s\n" % options.comment)
+                except:
+                    verbose_stderr("zlock: failed to write README for %s" % filesystem)
+            verbose_stderr("zlock: locked %s" % filesystem)
+            return True
+        except OSError:
+            # failed to acquire lock
+            verbose_stderr("zlock: failed to lock %s%s" % (filesystem, readme_comment(readme, " - ")))
+            return False
+
+def unlock(filesystem, options):
+    """Attempt to unlock filesystem, return whether we did."""
+    lockpath = os.path.join(LOCKDIR, filesystem2lockfile(filesystem))
+    readme = os.path.join(lockpath, "README")
+    if options.dryrun:
+        # test whether lock is available, don't actually acquire it
+        if os.path.isdir(lockpath):
+            verbose_stderr("zlock: (dry-run) would unlock %s" % filesystem)
+            return True
+        else:
+            verbose_stderr("zlock: (dry-run) would fail to unlock %s (no such lock)" % filesystem)
+            return False
+    else:
+        if os.path.exists(readme):
+            os.unlink(readme)
+        try:
+            os.rmdir(lockpath)
+        except OSError:
+            verbose_stderr("zlock: failed to unlock %s (no such lock)" % filesystem)
+            return False
+        verbose_stderr("zlock: unlocked %s" % filesystem)
+        return True
+
+def list_locks(options):
+    for lockfile in os.listdir(LOCKDIR):
+        filesystem = lockfile2filesystem(lockfile)
+        if options.verbose:
+            print("%s%s" % (filesystem, lockpath_comment(os.path.join(LOCKDIR, lockfile), " - ")))
+        else:
+            print("%s" % filesystem)
+
+def main():
+    usage = "usage: %prog [options] [lock|unlock|list] [<filesystem>]"
+    parser = optparse.OptionParser(usage)
+    parser.add_option('-c', '--comment', action='store', dest='comment', default=None, help='comment explaining reason for lock (default: %default)')
+    parser.add_option('-v', '--verbose', action='store_true', dest='verbose', default=False, help='be verbose (default: %default)')
+    parser.add_option('-n', '--dry-run', action='store_true', dest='dryrun', default=False, help='don\'t actually take any locks')
+    (options, args) = parser.parse_args(sys.argv)
+
+    set_verbose(options.verbose)
+    ensure_lockdir_exists()
+
+    try:
+        if len(args) == 3 and args[1] == "lock":
+            success = lock(args[2], options)
+        elif len(args) == 3 and args[1] == "unlock":
+            success = unlock(args[2], options)
+        elif len(args) == 2 and args[1] == "list":
+            success = list_locks(options)
+        else:
+            stderr(usage)
+            sys.exit(1)
+    except Exception, e:
+        # report exception and exit
+        message = "zlock failed with exception: %s" % e
+        stderr(message)
+        sys.exit(1)
+
+    if not success:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/bin/zlock
+++ b/bin/zlock
@@ -13,7 +13,9 @@
 import optparse
 import os
 import os.path
+from stat import ST_MTIME
 import sys
+import time
 from zfstools.util import stderr, verbose_stderr, set_verbose
 
 LOCKDIR = "/var/lib/zfs-tools/zlock"
@@ -93,9 +95,12 @@ def unlock(filesystem, options):
 
 def list_locks(options):
     for lockfile in os.listdir(LOCKDIR):
+        lockpath = os.path.join(LOCKDIR, lockfile)
         filesystem = lockfile2filesystem(lockfile)
         if options.verbose:
-            print("%s%s" % (filesystem, lockpath_comment(os.path.join(LOCKDIR, lockfile), " - ")))
+            mtime = os.stat(lockpath)[ST_MTIME]
+            timestamp = time.strftime("%Y-%m-%d-%H%M", time.localtime(mtime))
+            print("%s %s%s" % (filesystem, timestamp, lockpath_comment(lockpath, " ")))
         else:
             print("%s" % filesystem)
 

--- a/contrib/transfer-zfs-filesystem
+++ b/contrib/transfer-zfs-filesystem
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+#
+# transfer zfs filesystem (and all children) from one server to another, with locking by zlock.
+#
+# Author: Simon Guest, 24/9/2014
+
+import optparse
+import socket
+import subprocess
+import sys
+
+def lock_or_unlock(function, filesystem, options):
+    if ':' in filesystem:
+        fs_host, fs = filesystem.split(':')
+        hostname = socket.gethostname().split('.')[0] # lose the domain part
+        cmd = ['ssh', fs_host, 'zlock', '-c', '"transfer-zfs-replicas on %s"' % hostname]
+    else:
+        cmd = ['zlock', '-c', 'transfer-zfs-replicas']
+        fs = filesystem
+    if options.verbose:
+        cmd += ['-v']
+    if options.dryrun:
+        cmd += ['-n']
+    cmd += [function, fs]
+    if options.verbose:
+        sys.stderr.write("%s\n" % ' '.join(cmd))
+    rc = subprocess.call(cmd)
+    return rc == 0
+
+def lock(filesystem, options):
+    return lock_or_unlock('lock', filesystem, options)
+
+def unlock(filesystem, options):
+    return lock_or_unlock('unlock', filesystem, options)
+
+def highlight(line):
+    """Highlight a line in the output."""
+    return("========== %s ==========" % line)
+
+def keep_only(filesystem, n, tier, options):
+    zsnap_command = ['zsnap', '-k', str(n), '-p', 'auto-%s-' % tier, '--nosnapshot']
+    if options.verbose:
+        zsnap_command += ['-v']
+    if options.dryrun:
+        zsnap_command += ['-n']
+    zsnap_command += [filesystem]
+    if options.verbose:
+        sys.stderr.write("%s\n" % ' '.join(zsnap_command))
+    subprocess.check_call(zsnap_command)
+
+def transfer(source, destination, options):
+    if options.daily:
+        # purge all hourly, weekly, monthly snapshots, and just keep one daily
+        for tier,keep in [('hourly', 0), ('daily', 1), ('weekly', 0), ('monthly', 0)]:
+            keep_only(source, keep, tier, options)
+    zreplicate_command = ['zreplicate', '--create-destination']
+    if options.verbose:
+        zreplicate_command += ['-v']
+    if options.dryrun:
+        zreplicate_command += ['-n']
+    zreplicate_command += [source, destination]
+    if options.verbose:
+        sys.stderr.write("%s\n" % highlight(' '.join(zreplicate_command)))
+    subprocess.check_call(zreplicate_command)
+
+def lock_and_transfer(source, destination, options):
+    if lock(source, options):
+        try:
+            if options.lock:
+                if lock(options.lock, options):
+                    try:
+                        transfer(source, destination, options)
+                    finally:
+                        unlock(options.lock, options)
+                else:
+                    sys.stderr.write("failed to acquire lock for %s - skipping\n" % options.lock)
+            else:
+                transfer(source, destination, options)
+        finally:
+            unlock(source, options)
+    else:
+        sys.stderr.write("failed to acquire lock for %s - skipping\n" % source)
+
+def main():
+    usage = "usage: %prog [options] [<host>:]source-filesystem [<host>:]destination-filesystem"
+    parser = optparse.OptionParser(usage)
+    parser.add_option('-v', '--verbose', action='store_true', dest='verbose', default=False, help='be verbose (default: %default)')
+    parser.add_option('-n', '--dry-run', action='store_true', dest='dryrun', default=False, help='don\'t actually manipulate any file systems')
+    parser.add_option('-d', '--just-latest-daily', action='store_true', dest='daily', default=False, help='purge hourly, weekly, monthly, and all but one daily')
+    parser.add_option('-l', '--lock', action='store', dest='lock', metavar='HOST-FILESYSTEM', default=None, help='lock filesystem on remote server also')
+    (options, args) = parser.parse_args(sys.argv)
+
+    if len(args) != 3:
+        sys.stderr.write("%s\n" % usage)
+        sys.exit(1)
+
+    lock_and_transfer(args[1], args[2], options)
+
+if __name__ == "__main__":
+    main()

--- a/doc/README-zbackup.md
+++ b/doc/README-zbackup.md
@@ -21,6 +21,13 @@
 
    Replication is done for a single tier only, as per the 'replicate' property. Again, these properties must have the source being local to have any effect. Note that the `--no-replication-stream` option for zreplicate is used, so that no destination replica snapshots and filesystems are deleted as a side-effect of running a backup.  To purge obsolete snapshots from the destination, it is recommended to use the behaviour described in the previous paragraph.
 
+## Locking of filesystems during replication
+Replicating a large filesystem can take many hours, perhaps so long that another zbackup instance is started by cron in the meantime.  For this reason, all filesystems to be replicated are first locked using `zlock`.  A subsequent `zbackup` will simply skip any such locked filesystem.
+
+To manually disable replication of a filesystem, `zlock` may be run by hand.  This may be useful for example when migrating replicas from one replica server to another.  See `zlock --help` for details.
+
+Note that `zlock` has no effect beyond disabling replication by `zbackup`.  (It does nothing at the ZFS filesystem level.  It simply creates a lockfile in */var/lib/zfs-tools/zlock*, which is checked only by later instances of `zlock`.)
+
 ## ssh authentication
    It is up to you to arrange your own ssh authentication.  For example, you could use an ssh agent and ssh public key authentication, or say Kerberos.  (The crontab example below assumes Kerberos, which explains the call to kinit to acquire a Kerberos ticket from the local keytab file.)
 ## Interfacing with cron

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
 					]),
 	classifiers = classifiers,
 	packages=["zfstools"],
-	scripts=["bin/zreplicate", 'bin/zfs-shell', 'bin/zsnap', 'bin/zbackup'],
+	scripts=["bin/zreplicate", 'bin/zfs-shell', 'bin/zsnap', 'bin/zbackup', 'bin/zlock'],
 	keywords="ZFS filesystems backup synchronization snapshot",
 	zip_safe=False,
 )


### PR DESCRIPTION
I added a locking script called zlock, which is used by zbackup to acquire a lock on a ZFS filesystem.  This prevents concurrent replication.  The point is, zbackup is usually invoked from cron, say nightly, but the initial replication can take many days to complete.  This new function inhibits subsequent replications by zbackup, until the initial one is complete.  An additional benefit is that zlock can be called by hand, to prevent zbackup replication from occurring. for example if it is desired to migrate the replicas from one replica server to another.

Note as per the README, zlock in fact does nothing at the level of the ZFS filesystem;  it merely records a lockfile in /var/lib/zfs-tools/zlock which is checked by other invocations of zlock.
