### PR TITLE
fixes package_dir path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
 	license="GPL",
 	url='http://github.com/Rudd-O/zfs-tools',
 	package_dir=dict([
-					("zfstools", "src/zfstools"),
+					("", "src"),
 					]),
 	classifiers = classifiers,
 	packages=["zfstools"],


### PR DESCRIPTION
fixes the import error on zbackup:

(env) aw@hyd06:~/zfstool$ virtualenv env
Running virtualenv with interpreter /usr/bin/python2
New python executable in /home/aw/zfstool/env/bin/python2
Also creating executable in /home/aw/zfstool/env/bin/python
Installing setuptools, pkg_resources, pip, wheel...done.
(env) aw@hyd06:~/zfstool$ git clone https://github.com/Rudd-O/zfs-tools.git
Cloning into 'zfs-tools'...
remote: Counting objects: 689, done.
remote: Total 689 (delta 0), reused 0 (delta 0), pack-reused 689
Receiving objects: 100% (689/689), 161.98 KiB | 0 bytes/s, done.
Resolving deltas: 100% (391/391), done.
Checking connectivity... done.
(env) aw@hyd06:~/zfstool$ source env/bin/activate
(env) aw@hyd06:~/zfstool$ cd zfs-tools/
(env) aw@hyd06:~/zfstool/zfs-tools$ ls
bin  contrib  debian  doc  Makefile  MANIFEST.in  README.md  setup.cfg  setup.py  src  TODO
(env) aw@hyd06:~/zfstool/zfs-tools$ python setup.py develop
running develop
running egg_info
creating zfs_tools.egg-info
writing zfs_tools.egg-info/PKG-INFO
writing top-level names to zfs_tools.egg-info/top_level.txt
writing dependency_links to zfs_tools.egg-info/dependency_links.txt
writing manifest file 'zfs_tools.egg-info/SOURCES.txt'
reading manifest file 'zfs_tools.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'zfs_tools.egg-info/SOURCES.txt'
running build_ext
Creating /home/aw/zfstool/env/lib/python2.7/site-packages/zfs-tools.egg-link (link to .)
Adding zfs-tools 0.4.4 to easy-install.pth file
Installing zreplicate script to /home/aw/zfstool/env/bin
Installing zfs-shell script to /home/aw/zfstool/env/bin
Installing zsnap script to /home/aw/zfstool/env/bin
Installing zbackup script to /home/aw/zfstool/env/bin

Installed /home/aw/zfstool/zfs-tools
Processing dependencies for zfs-tools==0.4.4
Finished processing dependencies for zfs-tools==0.4.4
(env) aw@hyd06:~/zfstool/zfs-tools$ cd ..
(env) aw@hyd06:~/zfstool$ zbackup
Traceback (most recent call last):
  File "/home/aw/zfstool/env/bin/zbackup", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/home/aw/zfstool/zfs-tools/bin/zbackup", line 15, in <module>
    from zfstools.util import stderr, verbose_stderr, set_verbose
ImportError: No module named zfstools.util



