### PR TITLE
Python 3 Regression - Properties as bytes[]

### DIFF
--- a/src/zfstools/models.py
+++ b/src/zfstools/models.py
@@ -156,7 +156,7 @@ class PoolSet:  # maybe rewrite this as a dataset or something?
             assert 0, repr(properties)
 
         def extract_properties(s):
-            s = s.decode() if isinstance(s, bytes) else s
+            s = s.decode('utf-8') if isinstance(s, bytes) else s
             items = s.strip().split( '\t' )
             assert len( items ) == len( properties ), (properties, items)
             propvalues = map( lambda x: None if x == '-' else x, items[ 1: ] )

--- a/src/zfstools/models.py
+++ b/src/zfstools/models.py
@@ -156,6 +156,7 @@ class PoolSet:  # maybe rewrite this as a dataset or something?
             assert 0, repr(properties)
 
         def extract_properties(s):
+            s = s.decode() if isinstance(s, bytes) else s
             items = s.strip().split( '\t' )
             assert len( items ) == len( properties ), (properties, items)
             propvalues = map( lambda x: None if x == '-' else x, items[ 1: ] )


### PR DESCRIPTION
While debugging the code using python 3, extract_properties(s) was getting a bytes[] instead of string which caused the split to fail.

Simple fix that should be compatible with all versions of Python.

I was debugging the code from my own main() scripts using Python 3.7.7.