### PR TITLE
Fix Python 2 Decode Bug

### DIFF
--- a/src/zfstools/models.py
+++ b/src/zfstools/models.py
@@ -1,9 +1,11 @@
 '''
 Tree models for the ZFS tools
 '''
-
+import sys
 from collections import OrderedDict
 from datetime import datetime
+
+is_py2=(sys.version_info[0] == 2)
 
 class Dataset(object):
     name = None
@@ -146,6 +148,7 @@ class PoolSet:  # maybe rewrite this as a dataset or something?
         return dset
 
     def parse_zfs_r_output(self, zfs_r_output, properties = None):
+        global is_py2
         """Parse the output of tab-separated zfs list.
 
         properties must be a list of property names expected to be found as
@@ -160,7 +163,7 @@ class PoolSet:  # maybe rewrite this as a dataset or something?
             assert 0, repr(properties)
 
         def extract_properties(s):
-            s = s.decode('utf-8') if isinstance(s, bytes) else s
+            if not is_py2 and isinstance(s, bytes): s = s.decode('utf-8')
             items = s.strip().split( '\t' )
             assert len( items ) == len( properties ), (properties, items)
             propvalues = map( lambda x: None if x == '-' else x, items[ 1: ] )
@@ -225,3 +228,4 @@ class PoolSet:  # maybe rewrite this as a dataset or something?
 
     def __iter__(self):
         return self.walk()
+    

--- a/src/zfstools/models.py
+++ b/src/zfstools/models.py
@@ -228,4 +228,3 @@ class PoolSet:  # maybe rewrite this as a dataset or something?
 
     def __iter__(self):
         return self.walk()
-    


### PR DESCRIPTION
The last PR I merged had a regression with Python 2.x because a `str` in Python 2 is also a `bytes`. This Python 2 quirk causes the decode('utf-8') block to always execute. This patch detects the Python version and only calls decode('utf-8') if its not python 2.

I discovered this whilst getting zfslib working on Python 2.7.18. Sorry I did not catch this bug earlier.