### PR TITLE
when listing zfs structure, only list dataset we will be working with

### DIFF
--- a/bin/zreplicate
+++ b/bin/zreplicate
@@ -68,8 +68,8 @@ set_verbose(opts.verbose)
 
 # ================ start program algorithm ===================
 
-src_conn = ZFSConnection(source_host, trust=opts.trust, sshcipher=opts.sshcipher, identityfile=opts.identityfile,  knownhostsfile=opts.knownhostsfile, verbose=opts.verbose)
-dst_conn = ZFSConnection(destination_host, trust=opts.trust, sshcipher=opts.sshcipher, identityfile=opts.identityfile, knownhostsfile=opts.knownhostsfile, verbose=opts.verbose)
+src_conn = ZFSConnection(source_host, subset=source_dataset_name, trust=opts.trust, sshcipher=opts.sshcipher, identityfile=opts.identityfile,  knownhostsfile=opts.knownhostsfile, verbose=opts.verbose)
+dst_conn = ZFSConnection(destination_host, subset=destination_dataset_name, trust=opts.trust, sshcipher=opts.sshcipher, identityfile=opts.identityfile, knownhostsfile=opts.knownhostsfile, verbose=opts.verbose)
 
 verbose_stderr("Replicating dataset %s:%s into %s:%s..." % (
 		source_host,source_dataset_name,

--- a/bin/zsnap
+++ b/bin/zsnap
@@ -60,7 +60,7 @@ if opts.property:
 
 # ================ start program algorithm ===================
 
-src_conn = ZFSConnection(source_host,properties=snapshot_properties.keys())
+src_conn = ZFSConnection(source_host, subset=source_dataset_name, properties=snapshot_properties.keys())
 snapshot_unique_name = snapshot_prefix + snapshot_postfix()
 flt = lambda x: x.name.startswith(snapshot_prefix) and (not snapshot_properties or x.get_property(snapshot_properties.keys()[0])==snapshot_properties.values()[0])
 

--- a/src/zfstools/models.py
+++ b/src/zfstools/models.py
@@ -182,11 +182,9 @@ class PoolSet:  # maybe rewrite this as a dataset or something?
                 dset, snapshot = dset.split("@")
             else:
                 snapshot = None
-            if "/" not in dset:  # pool name
-                if dset not in self.pools:
-                    self.pools[dset] = Pool(dset)
-                    fs = self.pools[dset]
             poolname, pathcomponents = dset.split("/")[0], dset.split("/")[1:]
+            if poolname not in self.pools:
+                self.pools[poolname] = Pool(poolname)
             fs = self.pools[poolname]
             for pcomp in pathcomponents:
                 # traverse the child hierarchy or create if that fails

--- a/src/zfstools/zreplicate.py
+++ b/src/zfstools/zreplicate.py
@@ -69,8 +69,8 @@ def main():
 
         # ================ start program algorithm ===================
 
-        src_conn = ZFSConnection(source_host, trust=opts.trust, sshcipher=opts.sshcipher, identityfile=opts.identityfile,  knownhostsfile=opts.knownhostsfile, verbose=opts.verbose)
-        dst_conn = ZFSConnection(destination_host, trust=opts.trust, sshcipher=opts.sshcipher, identityfile=opts.identityfile, knownhostsfile=opts.knownhostsfile, verbose=opts.verbose)
+        src_conn = ZFSConnection(source_host, subset=source_dataset_name, trust=opts.trust, sshcipher=opts.sshcipher, identityfile=opts.identityfile,  knownhostsfile=opts.knownhostsfile, verbose=opts.verbose)
+        dst_conn = ZFSConnection(destination_host, subset=destination_dataset_name, trust=opts.trust, sshcipher=opts.sshcipher, identityfile=opts.identityfile, knownhostsfile=opts.knownhostsfile, verbose=opts.verbose)
 
         verbose_stderr("Replicating dataset %s:%s into %s:%s..." % (
                         source_host,source_dataset_name,

--- a/src/zfstools/zsnap.py
+++ b/src/zfstools/zsnap.py
@@ -61,7 +61,7 @@ def main():
 
         # ================ start program algorithm ===================
 
-        src_conn = ZFSConnection(source_host,properties=snapshot_properties.keys())
+        src_conn = ZFSConnection(source_host, subset=source_dataset_name, properties=snapshot_properties.keys())
         snapshot_unique_name = snapshot_prefix + snapshot_postfix()
         flt = lambda x: x.name.startswith(snapshot_prefix) and (not snapshot_properties or x.get_property(snapshot_properties.keys()[0])==snapshot_properties.values()[0])
 


### PR DESCRIPTION
This modification substantially reduces the time to list datasets on very large backup servers.

This resolves originally closed issue #40.

I tried to find places in code to justify comment https://github.com/Rudd-O/zfs-tools/issues/40#issuecomment-960391112 but could not find any.
To my knowledge this is resolved by zfs itself when it resolves incremental send.

If I am wrong, please direct me to the place in code where relevant and I'll try to modify the change to reflect.
